### PR TITLE
fix variants stats

### DIFF
--- a/resources/js/models/AlienPackage.js
+++ b/resources/js/models/AlienPackage.js
@@ -73,9 +73,11 @@ export default class AlienPackage {
 			this.cve_metadata = data.cve_metadata
 			this.collectCves();
 		}
+		this.processStats();
+	}
 
+	processStats() {
 		var filestats = this.statistics.files;
-
 		this.progress =
 			filestats.audit_total == 0
 				? 100
@@ -89,7 +91,6 @@ export default class AlienPackage {
 					filestats.upstream_source_total) *
 			  100
 			: 0;
-
 	}
 
 	collectCves() {

--- a/resources/js/models/BinaryPackage.js
+++ b/resources/js/models/BinaryPackage.js
@@ -1,6 +1,6 @@
 import Tags from "./Tags";
 
-export default class AlienPackage {
+export default class BinaryPackage {
 	name = "";
 	version = "";
 	revision = "";

--- a/resources/js/models/SourceFile.js
+++ b/resources/js/models/SourceFile.js
@@ -1,4 +1,4 @@
-export default class AlienPackage {
+export default class SourceFile {
 	name = "";
 	sha1_cksum = "";
 	git_sha1 = null;

--- a/resources/js/pages/Solda.vue
+++ b/resources/js/pages/Solda.vue
@@ -1045,6 +1045,7 @@ export default {
         }
 
         merged_package.setVariantTags();
+        merged_package.processStats();
 
         if (!skip) new_packages.push(merged_package);
       }


### PR DESCRIPTION
fix for #37 

`.progress` and `.workload` properties are calculated in AlienPackage constructor method.

from AlienPackage.js, line 60-onwards:

```js
	constructor(data = {}) {
		if (data.id) this.id = data.id;
		if (data.tags) this.tags = data.tags;
		if (data.name) this.name = data.name;
		if (data.version) this.version = data.version;
		if (data.revision) this.revision = data.revision;
		if (data.variant) this.variant = data.variant;
		if (data.debian_matching) this.debian_matching = data.debian_matching;
		if (data.statistics) this.statistics = data.statistics;
		if (data.source_files) this.source_files = data.source_files;
		if (data.binary_packages) this.binary_packages = data.binary_packages;
		if (data.session_state) this.session_state = data.session_state
		if (data.cve_metadata && data.cve_metadata.result) {
			this.cve_metadata = data.cve_metadata
			this.collectCves();
		}

		var filestats = this.statistics.files;

		this.progress =
			filestats.audit_total == 0
				? 100
				: parseInt(
						(filestats.audit_done / filestats.audit_total) * 100
				  );
		this.workload = filestats.audit_done;
		this.workload_total = filestats.audit_total;
		this.match = this.debian_matching
			? (this.debian_matching.ip_matching_files /
					filestats.upstream_source_total) *
			  100
			: 0;

	}
```

However, when creating an AlienPackage without immediately setting `.statistics.*` properties, `.progress` and `.workload` are wrongly set, respectively, to 100% and 0. This happens when creating merged (i.e. with variants) packages, here (from Solda.vue, line 877 onwards):

```js
        var merged_package = new AlienPackage({
          name: variants[a][0].name,
          version: variants[a][0].version,
          revision: variants[a][0].revision,
          variant: true,
          session_state: variants[a][0].session_state
        });
```

So a separate method has been created to do such calculation, that is called by the constructor method but can be separately called also after creating an object.